### PR TITLE
Autofocus and 'not solved' eternal load fix

### DIFF
--- a/trix/trix_student/static/trix_student/src/app/assignments/controllers.coffee
+++ b/trix/trix_student/static/trix_student/src/app/assignments/controllers.coffee
@@ -98,7 +98,7 @@ angular.module('trixStudent.assignments.controllers', ['ngRoute'])
           $scope.saving = false
           $scope.howsolved = null
         .catch (response) ->
-          if reponse.status == 404  # Handle 404 just like 200
+          if response.status == 404  # Handle 404 just like 200
             $scope.saving = false
             $scope.howsolved = null
           else

--- a/trix/trix_student/views/login.py
+++ b/trix/trix_student/views/login.py
@@ -24,6 +24,7 @@ class TrixAuthenticationForm(AuthenticationForm):
     def __init__(self, request=None, *args, **kwargs):
         super(TrixAuthenticationForm, self).__init__(request, *args, **kwargs)
         redirect_url = request.GET.get('next')
+        self.fields['username'].widget.attrs.update({'autofocus': True})
         self.helper = FormHelper()
         self.helper.add_input(Submit('login', _('Log in'), formnovalidate=True))
         if redirect_url is not None:


### PR DESCRIPTION
Fixes #74 
Fix spelling mistake: reponse => response
This caused errors when clicking "not solved" on an assignment that was 
already not solved.