### PR TITLE
Removed unnecessary if check which was causing issues.

### DIFF
--- a/trix/trix_student/views/common.py
+++ b/trix/trix_student/views/common.py
@@ -45,8 +45,6 @@ class AssignmentListViewBase(ListView):
         Gets the progress a user has made. Hidden tasks are not counted unless user is an admin.
         """
         assignments = self.get_queryset()
-        if (not self.request.user.is_admin):
-            assignments = assignments.exclude(hidden=True)
         how_solved = models.HowSolved.objects.filter(assignment__in=assignments)\
             .filter(user=self.request.user.id)
         num_solved = how_solved.count()


### PR DESCRIPTION
Closes #79. The if check causing issues was superfluous since the assignments are filtered when fetched, using the proper way to check if the user is admin.