### PR TITLE
Requirements clean-up

### DIFF
--- a/docs/sysadmin/deploy.rst
+++ b/docs/sysadmin/deploy.rst
@@ -77,10 +77,9 @@ Trix is configured through a ``trix_settings.py`` file. Start by copying the fol
         'PORT': '5432',
         'OPTIONS': {
           'sslmode': 'require',
-      },
+        },
+      }
     }
-}
-    DATABASES = {'default': dj_database_url.config(default=DATABASE_URL)}
 
     # Set this to False to turn of debug mode in production
     DEBUG = False

--- a/docs/sysadmin/deploy.rst
+++ b/docs/sysadmin/deploy.rst
@@ -6,7 +6,7 @@ Setup Trix for production
 ********************
 Install dependencies
 ********************
-#. Python 3.6 or higher. Check your current version by running ``python --version``.
+#. Python 3.8 or higher. Check your current version by running ``python --version``.
 #. PIP_
 #. VirtualEnv_
 #. PostgreSQL server --- not needed if you just want to build the docs.
@@ -38,7 +38,7 @@ Install Trix
 
     $ cd ~/trixdeploy
     $ virtualenv venv
-    $ venv/bin/pip3 install psycopg2 dj-static trix
+    $ venv/bin/pip3 install psycopg2 trix
 
 
 *********************************
@@ -59,16 +59,27 @@ Copy this script into ``~/trixdeploy/manage.py``::
 Configure
 *********
 Trix is configured through a ``trix_settings.py`` file. Start by copying the following into
-``~/trixdeploy/trix_settings.py``::
+``~/trixdeploy/trix_settings.py`` and replace the database placeholders with your own::
 
     from trix.project.production.settings import *
-    import dj_database_url
 
     # Make this 50 chars and RANDOM - do not share it with anyone
     SECRET_KEY = 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 
     # Database config
-    DATABASE_URL = 'sqlite:///trixdb.sqlite'
+    DATABASES = {
+      'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'DATABASE_NAME',
+        'USER': 'DATABASE_USERNAME',
+        'PASSWORD': 'DATABASE_PASSWORD',
+        'HOST': 'DATABASE_HOST',
+        'PORT': '5432',
+        'OPTIONS': {
+          'sslmode': 'require',
+      },
+    }
+}
     DATABASES = {'default': dj_database_url.config(default=DATABASE_URL)}
 
     # Set this to False to turn of debug mode in production
@@ -182,8 +193,6 @@ Just to make sure everything works, run::
     $ cd ~/trixdeploy/
     $ venv/bin/python manage.py migrate
 
-This should create a file named ``~/trixdeploy/trixdb.sqlite``. You can remove that file now - it was just for testing.
-
 
 ********************
 Collect static files
@@ -193,15 +202,6 @@ Run the following command to collect all static files (CSS, javascript, ...) for
     $ venv/bin/python manage.py collectstatic
 
 The files are written to the ``staticfiles`` sub-directory (~/trixdeploy/staticfiles).
-
-
-********************
-Configure a database
-********************
-Configure a Postgres database by editing the ``DATABASE_URL`` setting in your ``trix_settings.py`` script.
-The format is::
-
-    DATABASE_URL = "postgres://USER:PASSWORD@HOST:PORT/NAME"
 
 
 **********************

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -6,10 +6,9 @@ Markdown>=3.4.1
 Pygments==2.13.0
 PyYAML==6.0
 cradmin-legacy==5.0.0
-psycopg2-binary==2.9.5
 
 # For Dataporten login
-django-allauth==0.51.0
+django-allauth==0.54.0
 
 #-e git://github.com/appressoas/django_cradmin.git#egg=django_cradmin
 

--- a/requirements/develop.txt
+++ b/requirements/develop.txt
@@ -1,5 +1,7 @@
 -r common.txt
 
+psycopg2-binary==2.9.*
+
 # For automating development tasks
 invoke==1.7.3
 

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,5 +1,4 @@
 -r common.txt
 
 gunicorn
-django-toolbelt
 psycopg2

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,11 +2,4 @@
 
 gunicorn
 django-toolbelt
-
-# For search
-#pyelasticsearch==0.6.1
-
-
-
-# WSGI
-dj-static==0.0.6
+psycopg2

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
         'Markdown>=3.4.1',
         'PyYAML>=6.0',
         'django-extensions',
-        'dj-database-url>=0.5.0',
         'cradmin_legacy>=5.0.0',
         'gunicorn',
     ],

--- a/trix/project/production/wsgi.py
+++ b/trix/project/production/wsgi.py
@@ -1,4 +1,3 @@
 from django.core.wsgi import get_wsgi_application
-from dj_static import Cling
 
-application = Cling(get_wsgi_application())
+application = get_wsgi_application()


### PR DESCRIPTION
Some requirements clean-up, trying to remove packages we no longer use or need:

- `dj_static`: as far as I can tell this is a leftover from some testing with Heroku, and the package was abandoned years ago  
- `psycopg2-binary`: the binary-only package is not recommended for production (we don't use it for our deployment) so I assume it should be split with `psycopg2-binary` for development and `psycopg2` for production
- `django-allauth`: bumped to the version we currently support

----

~~I'm not sure why `django-toolbelt` is included for production?~~

~~It's not on PyPI, and the only reference to it in this repo is @espenak removing the explicit requirement for Gunicorn in 6480d8e298c5a13bae7df274cc2319f403addebb in June 2014 since «[gunicorn] is in django-toolbelt». My guess is that that package also is abandoned, but since we haven't used other means to update/install than `requirements/production.txt` we haven't noticed it.~~

`django-toolbelt` looks to have been a collection of `django`, `psycopg2`, `gunicorn`, `dj-database-url` and `dj-static`; we currently need 3/5 of them and it's better practice to import them explicitely.